### PR TITLE
Correct license from MIT to Apache 2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ author-email = ysuresh@redhat.com
 description = A Python package to scrape OpenShift/Kubernetes cluster failures
 long-description = file: README.md
 long-description-content-type = text/markdown; charset=UTF-8
-license = mit
+license = Apache License 2.0
 license_file = LICENSE
 url = https://github.com/openshift-scale/cerberus-api-client
 classifiers =


### PR DESCRIPTION
### Description

Correct the license declared in setup.cfg. Was set to MIT when it should be set to Apache 2.0

For reference, set the license string by example from https://github.com/apache/airflow/blob/main/setup.cfg, which also uses Apache 2.0